### PR TITLE
Make NGLView an optional dependency

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Test on py${{ matrix.python-version }}/${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]

--- a/environment.yml
+++ b/environment.yml
@@ -6,13 +6,14 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - mdanalysis>=2.0.0, <2.1
-  - nglview>=3.0.3, <3.1
+  - mdanalysis
+  - nglview
   - numpy
   - openmm
   - pandas
   - pdbfixer
   - psi4
+  - pytest
   - pytest-cov
   - pyyaml
   - rdkit

--- a/mdsapt/__init__.py
+++ b/mdsapt/__init__.py
@@ -7,7 +7,6 @@ from . import log
 from .reader import InputReader
 from .optimizer import Optimizer
 from .sapt import TrajectorySAPT
-from .viewer import Viewer
 
 # Handle versioneer
 from ._version import get_versions

--- a/mdsapt/viewer.py
+++ b/mdsapt/viewer.py
@@ -5,6 +5,11 @@ r"""
 Allows for visualization of trajectories using `NGLView <http://nglviewer.org>`_
 in a Jupyter Notebook.
 
+.. note::
+    This module only works if NGLView is installed. It is likely not
+    automatically installed by your package manager because it is an optional
+    dependency.
+
 Required Input:
 
 - :class:`-mdsapt.reader.InputReader
@@ -17,7 +22,13 @@ Required Input:
 
 from typing import Union
 
-import nglview as nv
+try:
+    import nglview as nv
+except ImportError:
+    raise ImportError(
+        "nglview is not installed! Please install it to use the viewer module."
+    )
+    
 import numpy as np
 
 from .sapt import TrajectorySAPT

--- a/meta.yaml
+++ b/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   run:
     - psi4
     - mdanalysis
-    - nglview
     - numpy
     - openmm
     - pandas
@@ -39,6 +38,7 @@ test:
   requires:
     - pip
     - pytest
+    - nglview
   commands:
     - pip check
     # This is currently disabled because it does not work.


### PR DESCRIPTION
This change makes NGLView an optional dependency. It fixes Mac builds, and reduces the dependency footprint.