### PR TITLE
Create nix build of MD-SAPT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+result/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An MDAnalysis-kit for calculating SAPT of molecular dynamics trajectories in psi
 
 ### Installation
 
-Installing with Conda on Python version 3.9 to 3.11 using the command:
+Installing with Conda on Python version 3.9 to 3.11 on either MacOS (arm or x86) or Linux using the command:
 
 ``` bash
 conda install -c conda-forge mdsapt
@@ -25,7 +25,18 @@ git clone https://github.com/calpolyccg/MDSAPT.git
 pip install ./MDSAPT
 ```
 
-A development environment can also be created using nix:
+If you use [nix](https://nixos.wiki/) MD-SAPT can be also be build with:
+
+```
+git clone https://github.com/calpolyccg/MDSAPT.git
+cd MDSAPT
+nix build
+```
+
+You can also incorporate it to a project managed with nix by adding it to the imports of your `flake.nix` or `shell.nix`.
+
+### Contributing
+A development environment can be created using nix:
 
 ``` bash 
 git clone https://github.com/calpolyccg/MDSAPT.git

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,6 +14,16 @@ Alternatively, it can be installed by cloning the GitHub repository.
     git clone https://github.com/calpolyccg/MDSAPT.git
     pip install ./MDSAPT
 
+If you use [nix](https://nixos.wiki/) MD-SAPT can be also be build with:
+
+```
+git clone https://github.com/calpolyccg/MDSAPT.git
+cd MDSAPT
+nix build
+```
+
+You can also incorporate it to a project managed with nix by adding it to the imports of your `flake.nix` or `shell.nix`.
+
 To ensure it's been installed correctly, run `mdsapt` or `python3 -m mdsapt`.
 
 .. code-block:: bash

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,6 @@
           mrcfile = [ "setuptools" ];
           griddataformats = [ "setuptools" ];
           pyright = [ "setuptools" ];
-          #matplotlib = [ "pybind11" ];
-          #scipy = [ "setuptools" "wheel" "pybind11" "pythran" ];
         };
 
         p2n-overrides = pkgs.poetry2nix.defaultPoetryOverrides.extend (final: prev:
@@ -60,16 +58,35 @@
           overrides = [ p2n-overrides unfuckScipy unfuckNumpy ]; #unfuckScipy ];
         };
 
+        nonPoetryPkgs = final: prev: {
+          psi4 = pkgs.qchem.psi4;
+          openmm = pkgs.qchem.openmm;
+          pdbfixer = pkgs.qchem.pdbfixer;
+        };
+
         devEnv = pkgs.mkShell {
-          propagatedBuildInputs = [ poetryEnv];
+          propagatedBuildInputs = [ poetryEnv ];
           buildInputs = with pkgs; [pkgs.qchem.psi4 pkgs.qchem.openmm pkgs.qchem.pdbfixer pkgs.act ];
         };
+
 
         # DON'T FORGET TO PUT YOUR PACKAGE NAME HERE, REMOVING `throw`
         packageName = "MD-SAPT";
 
+
+        app = pkgs.poetry2nix.mkPoetryApplication {
+          projectDir = ./.;
+          python = python;
+          overrides = [ p2n-overrides nonPoetryPkgs unfuckScipy unfuckNumpy ];
+
+        };
+
+
       in {
+        packages.${packageName} = app;
+        packages.default = self.packages.${system}.${packageName};
         devShells.default = devEnv;
+
       });
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,11 @@
 [tool.poetry]
 name = "mdsapt"
-version = "2.0.3"
+version = "2.0.4"
 description = "SAPT energy calculator built using MDAnalysis and Psi4"
-authors = ["Alia Lescoulie <alia.lescoulie@gmail.com>"]
+authors = [
+    "Alia Lescoulie <alia.lescoulie@gmail.com>",
+    "Astrid Yu <astrid@astrid.tech",
+    "Ashley Ringer McDonald <armcdona@calpoly.edu"]
 license = "GPL-3.0"
 readme = "README.md"
 
@@ -22,8 +25,9 @@ pytest-cov = "^5.0.0"
 autopep8 = "^2.2.0"
 pydantic = "^2.7.4"
 
-
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+mdsapt = "mdsapt:cli"


### PR DESCRIPTION
## Description
Create a way to build MD-SAPT using nix. This results in MD-SAPT being avaliable on NixOS, and provides an alternative way to build it without using Conda.

## TODO

- [x] Add info to readme and docs about nix build